### PR TITLE
Added Matplotlib to docsets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ build-scipy:
 
 build-statsmodels:
 	./build-docset.sh statsmodels source/statsmodels.sourceforge.net/stable
+	
+build-matplotlib:
+	./build-docset.sh Matplotlib source/matplotlib.org
 
 fetch-pandas:
 	wget -r --no-parent -P source http://pandas.pydata.org/pandas-docs/stable/
@@ -41,15 +44,20 @@ fetch-scipy:
 fetch-statsmodels:
 	wget -r --no-parent -P source http://statsmodels.sourceforge.net/stable/
 	wget -r --no-parent -P source http://statsmodels.sourceforge.net/stable/_static/searchtools.js
+	
+fetch-matplotlib:
+	wget -r --no-parent -P source http://matplotlib.org/contents.html
 
 fetch:
 	make fetch-pandas
 	make fetch-numpy
 	make fetch-scipy
 	make fetch-statsmodels
+	make fetch-matplotlib
 
 build:
 	make build-pandas
 	make build-numpy
 	make build-scipy
 	make build-statsmodels
+	make build-matplotlib

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Provides docsets for the [Dash](http://kapeli.com/dash) and [Zeal](http://zealdo
 * [SciPy](http://docs.scipy.org/doc/scipy/reference/)
 * [pandas](http://pandas.pydata.org/pandas-docs/stable/)
 * [statsmodels](http://statsmodels.sourceforge.net/stable/)
+* [matplotlib](http://matplotlib.org/)
 
 All docsets are set to use the Python language family and are added under the `python:` keyword by default. The scripts used to build the docsets are included.
 
@@ -17,6 +18,7 @@ Add any or all of the following feeds to Dash:
 * SciPy: [https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/scipy.xml](https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/scipy.xml)
 * pandas: [https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/pandas.xml](https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/pandas.xml)
 * statsmodels: [https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/statsmodels.xml](https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/statsmodels.xml)
+* Matplotlib: [https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/matplotlib.xml](https://raw.github.com/sjpfenninger/dash-docsets/master/feeds/matplotlib.xml)
 
 ## Building the docsets
 

--- a/feeds/matplotlib.xml
+++ b/feeds/matplotlib.xml
@@ -1,0 +1,4 @@
+<entry>
+    <version>1.8.0</version>
+    <url>https://github.com/sjpfenninger/dash-docsets/releases/download/v0.1/matplotlib.tgz</url>
+</entry>


### PR DESCRIPTION
Hi again

I added support for Matplotlib.
I tried to guess the correct format for the feed-file, but it should be reviewed.

The documentation renders OK, albeit not perfect, as the screen can be a bit too narrow for the index page (and other pages if not run maximized on my 13" MBP):

![screen shot 2014-02-18 at 12 19 53](https://f.cloud.github.com/assets/2641327/2195347/17478a7a-989c-11e3-818c-df3db5643d21.png)

Until you merge or reject this, the Matplotlib docset can be downloaded [here](http://www.fys.ku.dk/~bzg778/matplotlib.tgz) :)
